### PR TITLE
Build on binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ![Github Actions Status](https://github.com/blois/js-module-renderer/workflows/Build/badge.svg)
 
+[![Binder Logo](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/blois/js-module-renderer/master?urlpath=lab%2Ftree%tests.ipynb)
+
 See https://github.com/Quansight-Labs/jupyter-output-spec.
 
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -3,6 +3,7 @@
 set -o errexit
 set -o xtrace
 
+jupyter labextension uninstall jupyter-offlinenotebook --no-build
 jlpm
 # Build Typescript source
 jlpm build

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o xtrace
+
+jlpm
+# Build Typescript source
+jlpm build
+# Link your development version of the extension with JupyterLab
+jupyter labextension link .

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,1 @@
+jupyterlab>=2.0.0

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   ],
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
-  "style": "style/index.css",
   "repository": {
     "type": "git",
     "url": "https://github.com/blois/js-module-renderer.git"


### PR DESCRIPTION
I added a file so we can build this on binder to try it out without cloning. 

This is the link for my local branch: https://mybinder.org/v2/gh/saulshanabrook/js-module-renderer/patch-1?urlpath=lab%2Ftree%tests.ipynb

But in the readme I pointed it to your master branch. 

I also removed a link to a non existant styles file from the package.json so it builds.